### PR TITLE
Fix: 事前準備資料のリンクを修正

### DIFF
--- a/index.markdown
+++ b/index.markdown
@@ -13,7 +13,7 @@ layout: home
 
 IoP ワークショップの事前配布資料です。当日のハンズオンに必要な環境構築の方法が記載されています。
 
-- [事前配布資料](https://ptk-y-nakahira.github.io/iop-lec-preparation/)
+- [事前配布資料](https://kamarqxjp.sharepoint.com/:f:/s/msteams_7262d0/Em2002t56dxAuo6nR8SET0MBxYIdREB0nzfzjsse0hfXjA?e=XZMEt9)
 
 <div style="height: 80px;"></div>
 


### PR DESCRIPTION
事前準備資料のURLが変更されたため、index.markdown内のリンクを修正しました。