### PR TITLE
Fix code examples and comments

### DIFF
--- a/0003_http/index.md
+++ b/0003_http/index.md
@@ -63,7 +63,6 @@ void http_test(String message) {
 
   http.begin("http://192.168.254.254:1880/api"); // URLに接続します
 
-  // こんにちわというメッセージを送信します
   int httpResponseCode = http.POST(message); // "POST"メソッドでリクエストを送信します
 
   if (httpResponseCode == 200) { // 正常に受信できた場合

--- a/0004_mqtt_pub/index.md
+++ b/0004_mqtt_pub/index.md
@@ -5,10 +5,7 @@ layout: page
 
 ```cpp
 /*  MQTT通信をするための拡張機能 PubSubClientを使います。
-    下記URLからダウンロードして、Ardino IDEの
-    スケッチ -> ライブラリをインクルード -> ライブラリを管理
-    からpubsubclientをインストールしてください。
-    https://www.arduino.cc/reference/en/libraries/pubsubclient/
+    Arduino IDEのライブラリマネージャから `PubSubClient` をインストールしてください。
  */
 
 #include <WiFi.h>
@@ -44,7 +41,7 @@ void loop() {
   // --- MQTT通信 --- //
   //------------------//
 
-  mqtt_publish_test("iopworkshop/test", "PromptK-Nakahira", "ありがとう");// トピック名、クライアントID、メッセージ を指定します
+  mqtt_publish_test("iopworkshop/test", "PromptX-Nakahira", "ありがとう");// トピック名、クライアントID、メッセージ を指定します
   // クライアントID、メッセージは自由に指定してください
   // ただし、クライアントIDが重複すると接続できません
   // クライアントIDは23文字以内の半角英数字で指定します

--- a/0005_mqtt_sub/index.md
+++ b/0005_mqtt_sub/index.md
@@ -5,9 +5,7 @@ layout: page
 
 ```cpp
 /*  MQTT通信をするための拡張機能 PubSubClientを使います。
-    下記URLからダウンロードして、Ardino IDEの
-    スケッチ -> ライブラリをインクルード -> ライブラリを管理
-    からpubsubclientをインストールしてください。
+    Arduino IDEのライブラリマネージャから `PubSubClient` をインストールしてください。
 
  */
 // https://www.arduino.cc/reference/en/libraries/pubsubclient/
@@ -52,7 +50,8 @@ void loop() {
   //------------------//
 
   const char* topic = "iopworkshop/test";
-  const char* device_id = "PromptK-Nakahira-button";
+  const char* device_id = "PromptX-Nakahira-button";
+  // device_id (クライアントID) はMQTTブローカー内でユニークである必要があります。他のデバイスと重複しないように設定してください。
   mqtt_subscribe_test(topic, device_id); // トピック名を指定
 }
 


### PR DESCRIPTION
コード例のコメントとクライアントIDを修正しました。

- `0003_http/index.md`: 不要なコメントを削除
- `0004_mqtt_pub/index.md`: PubSubClientのインストール方法のコメントを修正、クライアントIDを `PromptK-Nakahira` から `PromptX-Nakahira` に変更
- `0005_mqtt_sub/index.md`: PubSubClientのインストール方法のコメントを修正、クライアントIDを `PromptK-Nakahira-button` から `PromptX-Nakahira-button` に変更し、`device_id` のユニーク性に関するコメントを追加